### PR TITLE
Enable source image build for pull requests build

### DIFF
--- a/.tekton/rekor-search-ui-pull-request.yaml
+++ b/.tekton/rekor-search-ui-pull-request.yaml
@@ -30,6 +30,8 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: build-source-image
+    value: 'true'
   pipelineSpec:
     finally:
     - name: show-sbom


### PR DESCRIPTION
This is for testing a frequent failure reported by rekor-search UI developers. To see if the built source container image is pushed to Quay.io properly at the end of the build process.